### PR TITLE
Fixes to CloseButton in ContentDialog

### DIFF
--- a/src/lib/ContentDialog/ContentDialog.scss
+++ b/src/lib/ContentDialog/ContentDialog.scss
@@ -21,25 +21,34 @@
 			inline-size: 540px;
 		}
 	}
-	
+
 	&-container {
 		@include flex($direction: row, $align: start);
 		#close-button {
 			@include flex($direction: column, $align: center, $justify: center);
+			color: var(--text-primary);
 			top: 0;
 			margin-inline-start: 8px;
-			block-size: 4.5rem;
-			inline-size: 4.5rem;
+			block-size: 48px;
+			inline-size: 48px;
+			padding: 0;
 			border-radius: var(--overlay-corner-radius);
-			outline: none;
 			border: 1px solid var(--surface-stroke-default);
 			background-clip: padding-box;
 			background-color: var(--control-on-image-fill-default);
-			transition: background-color var(--control-fast-duration) var(--control-fast-out-slow-in-easing);
+			transition: background-color var(--control-fast-duration)
+					var(--control-fast-out-slow-in-easing),
+				color var(--control-fast-duration) var(--control-fast-out-slow-in-easing);
 			&:hover {
 				background-color: var(--control-on-image-fill-secondary);
-			}&:active {
+			}
+			&:active {
 				background-color: var(--control-on-image-fill-tertiary);
+			}
+			&.disabled {
+				pointer-events: none;
+				color: var(--text-disabled);
+				background-color: var(--control-on-image-fill-default) !important;
 			}
 		}
 	}

--- a/src/lib/ContentDialog/ContentDialog.svelte
+++ b/src/lib/ContentDialog/ContentDialog.svelte
@@ -50,6 +50,7 @@
 	const forwardEvents = createEventForwarder(get_current_component(), [
 		"open",
 		"close",
+		"closeByButton",
 		"backdropclick",
 		"backdropmousedown"
 	]);
@@ -68,6 +69,13 @@
 
 	function close() {
 		open = false;
+	}
+
+	function closeByButton() {
+		if (closable) {
+			close();
+			dispatch("closeByButton");
+		}
 	}
 
 	function handleEscapeKey({ key }: KeyboardEvent) {
@@ -121,7 +129,13 @@
 				{/if}
 			</div>
 			{#if closeButton}
-				<button id="close-button" on:click={close} aria-label="Close dialog">
+				<button
+					id="close-button"
+					aria-label="Close dialog"
+					tabindex="0"
+					class:disabled={!closable}
+					on:click={closeByButton}
+				>
 					<svg
 						aria-hidden="true"
 						xmlns="http://www.w3.org/2000/svg"

--- a/src/routes/test/index.svelte
+++ b/src/routes/test/index.svelte
@@ -128,9 +128,6 @@
 
 <div style="height: 56px;" />
 
-<ContentDialog open closeButton>
-	test
-</ContentDialog>
 <PageSection>
 	<h2>fluent-svelte test page</h2>
 	<p>Made with <a href="https://kit.svelte.dev">SvelteKit</a></p>


### PR DESCRIPTION
- Added a new event called `on:closeByButton`
- Fixed the sizing issue
- Button is no longer clickable and disabled when the dialog is not closable